### PR TITLE
Inclui pagina para Wiki em quero-quero.md

### DIFF
--- a/Passaros/quero-quero.md
+++ b/Passaros/quero-quero.md
@@ -2,6 +2,8 @@
 
 O quero-quero (Brasil) ou abibe-do-sul (Portugal) (nome científico: Vanellus chilensis (Molina, 1782)), também conhecido por tetéu, téu-téu, teréu-teréu e terém-terém, é uma ave da ordem dos Charadriiformes, pertencendo à família dos Charadriidae. Em castelhano é conhecido por tero ou tero-tero, e em inglês como southern lapwing. Ocorre em toda a América do Sul e em alguns pontos da América Central, e sendo uma ave muito popular acabou por fazer parte do folclore de várias regiões.
 
+Fonte: Wikipédia - Quero-Quero [[link](https://pt.wikipedia.org/wiki/Quero-quero)]
+
 ### Código do Risco de Extinção
 
 LC - Pouco Preocupante


### PR DESCRIPTION
Inclui no fim da primeira sessão da pagina Quero-Quero a fonte da wikipédia.

Levantado por essa [issue](https://github.com/Alexsandr0x/pratica-code-review-passaros/issues/4) e seguindo os direcionamentos de Readme desse repósitório é obrigatório esse link em todas as paginas.

A fins de padronização foi usado da mesmo forma que apresentado na pagina moa.md